### PR TITLE
Fallback useId for React < 18

### DIFF
--- a/src/FileIcon.js
+++ b/src/FileIcon.js
@@ -69,6 +69,11 @@ const FOLD = {
 
 const LABEL_HEIGHT = 14;
 
+const useId = React.useId || (() => {
+  let i = 0;
+  return () => i++;
+})();
+
 export const FileIcon = ({
   color = 'whitesmoke',
   extension,
@@ -83,7 +88,7 @@ export const FileIcon = ({
   radius = 4,
   type,
 }) => {
-  const id = React.useId();
+  const id = useId();
   const UNIQUE_ID = typeof jest === 'undefined' ? id : '';
 
   return (


### PR DESCRIPTION
Improvement to PR #52.

---

When using SSR (e.g. with Remix or Next) `lodash.uniqueid` will cause a hydration mismatch warning because the server will have different IDs from the client.

This PR uses `React.useId()` which returns a unique ID that is stable between client and server. I also omit IDs when jest is defined so that the test snapshots will match.

For React < 18 where `React.useId()` is absent, a simple replacement function is used.
